### PR TITLE
Adds wrapping (w) ability in detailed log viewer

### DIFF
--- a/internal/tui/modals.go
+++ b/internal/tui/modals.go
@@ -301,6 +301,12 @@ func (m *DashboardModel) renderModalStatusBar() string {
 			if m.aiClient != nil {
 				statusItems = append(statusItems, "i: AI Analysis")
 			}
+			// Add wrapping toggle for log details modal
+			if m.attributeWrappingEnabled {
+				statusItems = append(statusItems, "w: Disable wrapping")
+			} else {
+				statusItems = append(statusItems, "w: Enable wrapping")
+			}
 			statusItems = append(statusItems, "↑↓/Wheel: Scroll", "PgUp/PgDn: Page")
 		}
 	} else {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -111,6 +111,9 @@ type DashboardModel struct {
 	logAutoScroll    bool // Auto-scroll to latest logs in log viewer
 	instructionsScrollOffset int // Scroll position for instructions/filter status screen
 
+	// Modal display options
+	attributeWrappingEnabled bool // Whether to wrap attribute values instead of truncating them
+
 	// Update interval management
 	availableIntervals []time.Duration
 	currentIntervalIdx int
@@ -283,6 +286,7 @@ func NewDashboardModel(maxLogBuffer int, updateInterval time.Duration, aiModel s
 		logAutoScroll:       true,               // Start with auto-scroll enabled
 		showColumns:         true,               // Show Host/Service columns by default
 		instructionsScrollOffset: 0,             // Start at top of instructions
+		attributeWrappingEnabled: false,         // Default to truncating (not wrapping)
 		// Initialize statistics tracking
 		statsStartTime:      time.Now(),
 		statsTotalBytes:     0,

--- a/internal/tui/navigation.go
+++ b/internal/tui/navigation.go
@@ -861,6 +861,16 @@ func (m *DashboardModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 					return m, nil
 				}
+			case "w":
+				// Toggle attribute wrapping - only when not in chat mode
+				if !m.chatActive {
+					m.attributeWrappingEnabled = !m.attributeWrappingEnabled
+					// Refresh the modal content with new wrapping setting
+					if m.currentLogEntry != nil {
+						m.modalContent = m.formatLogDetails(*m.currentLogEntry, 60)
+					}
+					return m, nil
+				}
 			case "escape", "esc": // escape to close modal (only if not in chat mode)
 				m.showModal = false
 				m.modalContent = ""
@@ -898,6 +908,14 @@ func (m *DashboardModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			case "pgdown":
 				m.infoViewport.HalfPageDown()
+				return m, nil
+			case "w":
+				// Toggle attribute wrapping
+				m.attributeWrappingEnabled = !m.attributeWrappingEnabled
+				// Refresh the modal content with new wrapping setting
+				if m.currentLogEntry != nil {
+					m.modalContent = m.formatLogDetails(*m.currentLogEntry, 60)
+				}
 				return m, nil
 			case "escape", "esc":
 				m.showModal = false


### PR DESCRIPTION
When viewing a log in detail, you can hit press `w` to wrap the attributes instead of truncate them, and then press `w` again to flip back.


<img width="1643" height="1010" alt="image" src="https://github.com/user-attachments/assets/ac9a2c96-42bd-4b48-aa2a-114912e0610a" />
