### PR TITLE
tui/components: hint at the `-f` flag

### DIFF
--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -327,7 +327,7 @@ func (m *DashboardModel) renderLogScrollContent(height int, logWidth int) []stri
 			"💡 To get started:",
 			"  • Pipe logs: cat mylog.json | gonzo",
 			"  • Stream logs: kubectl logs -f pod | gonzo",
-			"  • From file: gonzo < application.log",
+			"  • From file: gonzo -f application.log -f other.log -f 'dir/*.globlog'",
 			"",
 		}
 


### PR DESCRIPTION
The `gonzo < application.log` hint is the same core functionality as the hint to "Pipe logs"'s `cat application.log | gonzo` command. Instead, hint that the `-f` flag exists, that it may be repeated, and it supports globs as mentioned in the README.