### PR TITLE
Enabling severity filter modal for Log Viewer window

### DIFF
--- a/internal/tui/navigation.go
+++ b/internal/tui/navigation.go
@@ -217,10 +217,6 @@ func (m *DashboardModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.showCountsModal = false
 			return m, nil
 		}
-		if m.showLogViewerModal {
-			m.showLogViewerModal = false
-			return m, nil
-		}
 		if m.showSeverityFilterModal {
 			// Restore original state (cancel changes)
 			for k, v := range m.severityFilterOriginal {
@@ -229,6 +225,10 @@ func (m *DashboardModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.updateSeverityFilterActiveStatus()
 			m.updateFilteredView()
 			m.showSeverityFilterModal = false
+			return m, nil
+		}
+		if m.showLogViewerModal {
+			m.showLogViewerModal = false
 			return m, nil
 		}
 		if m.showModal {
@@ -394,7 +394,7 @@ func (m *DashboardModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "ctrl+f":
 		// Severity filter modal
-		if !m.showModal && !m.filterActive && !m.searchActive && !m.showHelp && !m.showPatternsModal && !m.showModelSelectionModal && !m.showStatsModal && !m.showCountsModal && !m.showLogViewerModal {
+		if !m.showModal && !m.filterActive && !m.searchActive && !m.showHelp && !m.showPatternsModal && !m.showModelSelectionModal && !m.showStatsModal && !m.showCountsModal {
 			// Store original state for ESC cancellation
 			m.severityFilterOriginal = make(map[string]bool)
 			for k, v := range m.severityFilter {
@@ -548,7 +548,7 @@ func (m *DashboardModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	
 	// Log viewer modal keyboard navigation
-	if m.showLogViewerModal {
+	if m.showLogViewerModal && !m.showSeverityFilterModal {
 		// Save the previous active section and temporarily activate log section
 		previousSection := m.activeSection
 		m.activeSection = SectionLogs

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -37,6 +37,11 @@ func (m *DashboardModel) View() string {
 		return m.renderCountsModal()
 	}
 	
+	// Show severity filter modal (check before log viewer so it can overlay)
+	if m.showSeverityFilterModal {
+		return m.renderSeverityFilterModal()
+	}
+
 	// Show log viewer modal (fullscreen log viewer)
 	if m.showLogViewerModal {
 		return m.renderLogViewerModal()
@@ -45,11 +50,6 @@ func (m *DashboardModel) View() string {
 	// Show model selection modal
 	if m.showModelSelectionModal {
 		return m.renderModelSelectionModal()
-	}
-
-	// Show severity filter modal
-	if m.showSeverityFilterModal {
-		return m.renderSeverityFilterModal()
 	}
 
 	// Show detail modal - use lipgloss overlay


### PR DESCRIPTION
This PR fixes #75 by moving the priority of the severity filter to be higher than the log viewer filter. 

With this change, the severity filter modal is accessible when the Log Viewer is full screen, allowing for severity changes without needing to go back to the main dashboard.