### PR TITLE
feat(timestamp): allow to switch between log time or record time

### DIFF
--- a/cmd/gonzo/app.go
+++ b/cmd/gonzo/app.go
@@ -102,7 +102,7 @@ func runApp(cmd *cobra.Command, args []string) error {
 	freqMemory := memory.NewFrequencyMemory(cfg.MemorySize)
 
 	// Initialize TUI model with components
-	dashboard := tui.NewDashboardModel(cfg.LogBuffer, cfg.UpdateInterval, cfg.AIModel, textAnalyzer.GetStopWords(), cfg.ReverseScrollWheel)
+	dashboard := tui.NewDashboardModel(cfg.LogBuffer, cfg.UpdateInterval, cfg.AIModel, textAnalyzer.GetStopWords(), cfg.ReverseScrollWheel, cfg.UseLogTime)
 	if versionChecker != nil {
 		dashboard.SetVersionChecker(versionChecker)
 	}

--- a/cmd/gonzo/main.go
+++ b/cmd/gonzo/main.go
@@ -53,6 +53,7 @@ type Config struct {
 	Format               string        `mapstructure:"format"`
 	DisableVersionCheck  bool          `mapstructure:"disable-version-check"`
 	ReverseScrollWheel   bool          `mapstructure:"reverse-scroll-wheel"`
+	UseLogTime           bool          `mapstructure:"use-log-time"`
 }
 
 var (
@@ -181,6 +182,7 @@ func init() {
 	rootCmd.Flags().String("format", "", "Log format to use (auto-detect if not specified). Can be: otlp, json, text, or a custom format name from ~/.config/gonzo/formats/")
 	rootCmd.Flags().Bool("disable-version-check", false, "Disable automatic version checking on startup")
 	rootCmd.Flags().Bool("reverse-scroll-wheel", false, "Reverse scroll wheel direction (natural scrolling)")
+	rootCmd.Flags().Bool("use-log-time", false, "Use original log timestamps instead of receive time for heatmap and display (falls back to receive time if log has no timestamp)")
 
 	// Bind flags to viper
 	viper.BindPFlag("memory-size", rootCmd.Flags().Lookup("memory-size"))
@@ -209,6 +211,7 @@ func init() {
 	viper.BindPFlag("format", rootCmd.Flags().Lookup("format"))
 	viper.BindPFlag("disable-version-check", rootCmd.Flags().Lookup("disable-version-check"))
 	viper.BindPFlag("reverse-scroll-wheel", rootCmd.Flags().Lookup("reverse-scroll-wheel"))
+	viper.BindPFlag("use-log-time", rootCmd.Flags().Lookup("use-log-time"))
 
 	// Add version command
 	rootCmd.AddCommand(versionCmd)

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -133,16 +133,29 @@ func (m *DashboardModel) renderStatusLine() string {
 		}
 	}
 
+	// Add timestamp mode indicator
+	var timestampMode string
+	if m.useLogTime {
+		if narrow {
+			timestampMode = "⏱Log"
+		} else {
+			timestampMode = "⏱ Log Time"
+		}
+	}
+
 	// Add branding (show unless terminal is very narrow)
 	branding := ""
 	if m.width >= 30 { // Show branding unless terminal is very narrow
 		branding = m.renderGonzoBranding()
 	}
 
-	// Combine status info, version update, and branding
+	// Combine status info, timestamp mode, version update, and branding
 	var rightParts []string
 	if statusInfo != "" {
 		rightParts = append(rightParts, statusInfo)
+	}
+	if timestampMode != "" {
+		rightParts = append(rightParts, timestampMode)
 	}
 	if versionUpdateInfo != "" {
 		rightParts = append(rightParts, versionUpdateInfo)

--- a/internal/tui/formatting.go
+++ b/internal/tui/formatting.go
@@ -10,8 +10,8 @@ import (
 
 // formatLogEntry formats a log entry with colors
 func (m *DashboardModel) formatLogEntry(entry LogEntry, availableWidth int, isSelected bool) string {
-	// Use receive time for display
-	timestamp := entry.Timestamp.Format("15:04:05")
+	// Use getDisplayTimestamp to respect the useLogTime setting
+	timestamp := m.getDisplayTimestamp(entry).Format("15:04:05")
 
 	// If selected, apply selection style to entire row
 	if isSelected {

--- a/internal/tui/modal_help.go
+++ b/internal/tui/modal_help.go
@@ -76,6 +76,7 @@ ACTIONS:
   f              - Open fullscreen log viewer modal
   Space          - Pause/unpause UI updates
   c              - Toggle Host/Service columns in log view
+  T              - Toggle timestamp mode (Log Time / Receive Time)
   r              - Reset all data (manual reset)
   u/U            - Cycle update intervals (forward/backward)
   i              - Show comprehensive statistics modal

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -93,6 +93,7 @@ type DashboardModel struct {
 	maxLogBuffer       int
 	updateInterval     time.Duration
 	reverseScrollWheel bool
+	useLogTime         bool // Use OrigTimestamp instead of Timestamp for heatmap/display
 
 	// Filter
 	filterInput  textinput.Model
@@ -244,7 +245,7 @@ func initializeDrain3BySeverity() map[string]*Drain3Manager {
 }
 
 // NewDashboardModel creates a new dashboard model with stop words
-func NewDashboardModel(maxLogBuffer int, updateInterval time.Duration, aiModel string, stopWords map[string]bool, reverseScrollWheel bool) *DashboardModel {
+func NewDashboardModel(maxLogBuffer int, updateInterval time.Duration, aiModel string, stopWords map[string]bool, reverseScrollWheel bool, useLogTime bool) *DashboardModel {
 	filterInput := textinput.New()
 	filterInput.Placeholder = "Filter logs by message or attributes (regex supported)..."
 	filterInput.CharLimit = 200
@@ -285,6 +286,7 @@ func NewDashboardModel(maxLogBuffer int, updateInterval time.Duration, aiModel s
 		maxLogBuffer:        maxLogBuffer,
 		updateInterval:      updateInterval,
 		reverseScrollWheel:  reverseScrollWheel,
+		useLogTime:          useLogTime,
 		filterInput:         filterInput,
 		searchInput:         searchInput,
 		chatInput:           chatInput,

--- a/internal/tui/navigation.go
+++ b/internal/tui/navigation.go
@@ -362,7 +362,15 @@ func (m *DashboardModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.showColumns = !m.showColumns
 			return m, nil
 		}
-		
+
+	case "T":
+		// Toggle timestamp mode (Log Time vs Receive Time)
+		if !m.showModal && !m.filterActive && !m.searchActive && !m.showSeverityFilterModal {
+			m.useLogTime = !m.useLogTime
+			m.rebuildHeatmap()
+			return m, nil
+		}
+
 	case "i":
 		// Toggle statistics modal
 		if !m.showModal && !m.filterActive && !m.searchActive && !m.showHelp && !m.showPatternsModal && !m.showModelSelectionModal && !m.showSeverityFilterModal {


### PR DESCRIPTION
By default, Gonzo will use the record time (when the log line was seen) instead of the timestamp in the log line (if available).

This causes weird situations when ingesting old logs (= not tailing) because the log time doesn't match.
With this change, users can now switch between modes by using `T`.

This is especially relevant for when gonzo is used with `-f log-file.txt`.

> [!WARNING]
> The code was fully generated by `claude-opus-4-5-20251101`.  
> It has been tested and works for my use case.