### PR TITLE
Extend the scope of k9s plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,11 +644,17 @@ plugins:
     description: "Gonzo log analysis"
     scopes:
       - po
+      - deploy
+      - sts
+      - ds
+      - svc
+      - job
+      - cj
     command: sh
     background: false
     args:
       - -c
-      - "kubectl logs -f --tail=0 $NAME -n $NAMESPACE --context $CONTEXT | gonzo"
+      - "kubectl logs -f --tail=0 $RESOURCE_NAME/$NAME -n $NAMESPACE --context $CONTEXT | gonzo"
 ```
 
 > ⚠️ NOTE: on `macOS` although it is not required, defining `XDG_CONFIG_HOME=~/.config` is recommended in order to maintain consistency with Linux configuration practices.


### PR DESCRIPTION
The current setup example of k9s plugin in the README.md works only with pods while the k9s native logs browsing also supports deployments, statefulsets, daemonsets, services, jobs and cronjobs.  With the new config Gonzo plugin shortcut will also be available for the mentioned resources.