### PR TITLE
fix scanner use. 

### DIFF
--- a/internal/filereader/filereader.go
+++ b/internal/filereader/filereader.go
@@ -31,7 +31,6 @@ type FileReader struct {
 // fileState tracks the current position and state of a file being followed
 type fileState struct {
 	file     *os.File
-	scanner  *bufio.Scanner
 	size     int64
 	modified time.Time
 }
@@ -214,17 +213,11 @@ func (fr *FileReader) setupFileWatcher(filePath string) error {
 		return err
 	}
 
-	scanner := bufio.NewScanner(file)
-	const maxScanTokenSize = 1024 * 1024 // 1MB
-	buf := make([]byte, maxScanTokenSize)
-	scanner.Buffer(buf, maxScanTokenSize)
-
 	// Store file state
 	fr.mu.Lock()
 	fr.watchers[filePath] = watcher
 	fr.fileStates[filePath] = &fileState{
 		file:     file,
-		scanner:  scanner,
 		size:     currentSize,
 		modified: info.ModTime(),
 	}
@@ -292,12 +285,20 @@ func (fr *FileReader) handleFileWrite(filePath string) {
 		return
 	}
 
+	// Create a fresh scanner each time — bufio.Scanner caches EOF internally
+	// and once it returns false, subsequent Scan() calls always return false
+	// even if new data has been appended to the underlying file.
+	scanner := bufio.NewScanner(state.file)
+	const maxScanTokenSize = 1024 * 1024 // 1MB
+	buf := make([]byte, maxScanTokenSize)
+	scanner.Buffer(buf, maxScanTokenSize)
+
 	// Read new lines
-	for state.scanner.Scan() {
+	for scanner.Scan() {
 		select {
 		case <-fr.ctx.Done():
 			return
-		case fr.lineChan <- state.scanner.Text():
+		case fr.lineChan <- scanner.Text():
 		}
 	}
 
@@ -334,15 +335,8 @@ func (fr *FileReader) reopenFile(filePath string) {
 		return
 	}
 
-	// Create new scanner
-	scanner := bufio.NewScanner(file)
-	const maxScanTokenSize = 1024 * 1024 // 1MB
-	buf := make([]byte, maxScanTokenSize)
-	scanner.Buffer(buf, maxScanTokenSize)
-
 	// Update state
 	state.file = file
-	state.scanner = scanner
 	state.size = 0
 
 	log.Printf("Reopened file %s (likely rotated)", filePath)


### PR DESCRIPTION
Fix Scanner for correct usage.

  The follow mode stored a single bufio.Scanner instance per file and reused it across every fsnotify write event. This is fundamentally incompatible with how Go's bufio.Scanner works.  When Scanner.Scan() reads to the end of available data, it encounters io.EOF and sets an internal done flag. Once set, all subsequent calls to Scan() return false immediately — even if new data has been appended to the underlying file handle. The scanner is a one-pass reader by design.

  The sequence was:

  1. Setup: setupFileWatcher opens the file, seeks to EOF, creates a bufio.Scanner, and stores it in fileState.scanner.
  2. First write event: handleFileWrite calls state.scanner.Scan(), reads the new lines, hits EOF — scanner is now permanently done.
  3. All subsequent write events: state.scanner.Scan() returns false immediately. No lines are ever read again.

  This explains why piping through tail -f worked as a workaround — stdin doesn't have the same EOF semantics since the pipe stays open.

  Fix

  Create a fresh bufio.Scanner on each write event instead of reusing a cached one. The underlying *os.File handle maintains its read position
  independently of the scanner, so each new scanner picks up exactly where the previous one left off.

  The scanner field was removed from fileState entirely since it is no longer persisted between events. Scanner creation was also removed from
  setupFileWatcher and reopenFile for the same reason.
