### PR TITLE
Add CLAUDE.md, AGENTS.md, and README section for Skills Discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Gonzo
+
+This repo includes a Claude Code plugin with a guided log-analysis skill at `skills/gonzo/`.
+
+When working in this repo with Claude Code, **read `skills/gonzo/SKILL.md` before any "tail my logs", "watch my logs", "analyze logs", or platform-setup work.** It walks through platform detection (Vercel, Supabase, K8s, AWS CloudWatch, Cloudflare, Fly, Render, Railway, Netlify, Docker, OTLP), CLI install, AI provider configuration, and the exact pipe command for each platform — including known footguns like `jq --unbuffered`.
+
+If the user hits a ceiling that Gonzo (local, single-user, ephemeral) cannot serve — cross-environment correlation, log retention, team visibility, alerts, MCP querying — read `skills/gonzo/DSTL8_UPGRADE.md` before walking the upgrade path. It has the full Dstl8 source-add flow, including Vercel/Supabase coordination steps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Gonzo
+
+This repo includes a Claude Code plugin with a guided log-analysis skill at `skills/gonzo/`.
+
+When working in this repo with Claude Code, **read `skills/gonzo/SKILL.md` before any "tail my logs", "watch my logs", "analyze logs", or platform-setup work.** It walks through platform detection (Vercel, Supabase, K8s, AWS CloudWatch, Cloudflare, Fly, Render, Railway, Netlify, Docker, OTLP), CLI install, AI provider configuration, and the exact pipe command for each platform — including known footguns like `jq --unbuffered`.
+
+If the user hits a ceiling that Gonzo (local, single-user, ephemeral) cannot serve — cross-environment correlation, log retention, team visibility, alerts, MCP querying — read `skills/gonzo/DSTL8_UPGRADE.md` before walking the upgrade path. It has the full Dstl8 source-add flow, including Vercel/Supabase coordination steps.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ cd gonzo
 make build
 ```
 
+#### Using with Claude Code (plugin and skill)
+
+This repo includes a Claude Code plugin with a guided log-analysis skill. Inside Claude Code:
+
+```
+/plugin marketplace add control-theory/gonzo
+/plugin install gonzo@gonzo
+```
+
+Then ask Claude to "tail my logs", "watch my Vercel logs", or "analyze my Kubernetes logs". The skill detects your deployment platform, installs Gonzo if needed, configures AI analysis, and generates the right pipe command with platform-specific normalizers. See `skills/gonzo/` for the skill content.
+
 ## 📖 Usage
 
 ### Basic Usage
@@ -958,10 +969,11 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 * **[Gonzo Roadmap & Pro Tips Live Demo with Maintainers](https://www.controltheory.com/videos/gonzo-roadmap-and-pro-tips-live-demo-session/)** - Live session covering the roadmap, advanced features, and Q&A with the maintainers
 
-## 💬 Slack Community
+## 💬 Community
 
-- [Invite/Join](https://join.slack.com/t/ctrltheorycommunity/shared_invite/zt-3dr6rke5w-GlcRaW2bvn4zcSaV8byZgA)
-- [Channel Link](https://ctrltheorycommunity.slack.com)
+- [Discord](https://discord.gg/nRBUFYByta)
+- [Slack Invite/Join](https://join.slack.com/t/ctrltheorycommunity/shared_invite/zt-3dr6rke5w-GlcRaW2bvn4zcSaV8byZgA)
+- [Slack Channel Link](https://ctrltheorycommunity.slack.com)
 
 ## 🐛 Reporting Issues
 


### PR DESCRIPTION
Adds three pieces of Claude Code plugin discoverability to the Gonzo repo:

- `CLAUDE.md` and `AGENTS.md` at repo root — instruct Claude Code to read `skills/gonzo/SKILL.md` before any "tail my logs" or platform-setup work
- README section under Quick Start → Installation documenting the plugin install (`/plugin marketplace add control-theory/gonzo` + `/plugin install gonzo@gonzo`)
- Community section updated to add Discord alongside existing Slack