### PR TITLE
fix: support multiple paths in KUBECONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Kubernetes Flags:
   --k8s-selector string            Kubernetes label selector for filtering pods
   --k8s-tail int                   Number of previous log lines to retrieve (default: 10)
   --k8s-since int                  Only return logs newer than relative duration in seconds
-  --k8s-kubeconfig string          Path to kubeconfig file (default: $HOME/.kube/config)
+  --k8s-kubeconfig string          Path to kubeconfig file (default: $KUBECONFIG or $HOME/.kube/config)
   --k8s-context string             Kubernetes context to use
 
   -t, --test-mode                  Run without TTY for testing

--- a/cmd/gonzo/app.go
+++ b/cmd/gonzo/app.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -808,42 +807,32 @@ func hasExplicitSourceFlag() bool {
 // 2. Otherwise, fall back to OS system logs
 func (m *simpleTuiModel) autoDetectLogSource() {
 	// Try kubeconfig first
-	kubeconfigPath := os.Getenv("KUBECONFIG")
-	if kubeconfigPath == "" {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			kubeconfigPath = filepath.Join(home, ".kube", "config")
+	if kubeconfigs := k8s.DetectKubeconfig(); len(kubeconfigs) > 0 {
+		// Kubeconfig found — auto-enable Kubernetes with all namespaces
+		log.Printf("Auto-detected kubeconfig at %s, enabling Kubernetes log streaming", strings.Join(kubeconfigs, ", "))
+		m.inputChan = make(chan string, 100)
+
+		// Kubeconfig left empty so client-go resolves KUBECONFIG itself
+		k8sConfig := &k8s.Config{
+			Context:    cfg.K8sContext,
+			Namespaces: cfg.K8sNamespaces,
+			Selector:   cfg.K8sSelector,
+			Since:      cfg.K8sSince,
+			TailLines:  cfg.K8sTailLines,
 		}
-	}
 
-	if kubeconfigPath != "" {
-		if _, err := os.Stat(kubeconfigPath); err == nil {
-			// Kubeconfig found — auto-enable Kubernetes with all namespaces
-			log.Printf("Auto-detected kubeconfig at %s, enabling Kubernetes log streaming", kubeconfigPath)
-			m.inputChan = make(chan string, 100)
-
-			k8sConfig := &k8s.Config{
-				Kubeconfig: kubeconfigPath,
-				Context:    cfg.K8sContext,
-				Namespaces: cfg.K8sNamespaces,
-				Selector:   cfg.K8sSelector,
-				Since:      cfg.K8sSince,
-				TailLines:  cfg.K8sTailLines,
+		k8sSource, err := k8s.NewKubernetesLogSource(k8sConfig)
+		if err == nil {
+			if err := k8sSource.Start(); err == nil {
+				m.hasK8sInput = true
+				m.k8sReceiver = k8sSource
+				m.dashboard.SetK8sSource(k8sSource)
+				go m.readK8sAsync()
+				return
 			}
-
-			k8sSource, err := k8s.NewKubernetesLogSource(k8sConfig)
-			if err == nil {
-				if err := k8sSource.Start(); err == nil {
-					m.hasK8sInput = true
-					m.k8sReceiver = k8sSource
-					m.dashboard.SetK8sSource(k8sSource)
-					go m.readK8sAsync()
-					return
-				}
-				log.Printf("Auto-detect: Kubernetes start failed: %v", err)
-			} else {
-				log.Printf("Auto-detect: Kubernetes init failed: %v", err)
-			}
+			log.Printf("Auto-detect: Kubernetes start failed: %v", err)
+		} else {
+			log.Printf("Auto-detect: Kubernetes init failed: %v", err)
 		}
 	}
 

--- a/cmd/gonzo/app.go
+++ b/cmd/gonzo/app.go
@@ -809,7 +809,7 @@ func (m *simpleTuiModel) autoDetectLogSource() {
 	// Try kubeconfig first
 	if kubeconfigs := k8s.DetectKubeconfig(); len(kubeconfigs) > 0 {
 		// Kubeconfig found — auto-enable Kubernetes with all namespaces
-		log.Printf("Auto-detected kubeconfig at %s, enabling Kubernetes log streaming", strings.Join(kubeconfigs, ", "))
+		log.Printf("Auto-detected kubeconfig(s): %s; enabling Kubernetes log streaming", strings.Join(kubeconfigs, ", "))
 		m.inputChan = make(chan string, 100)
 
 		// Kubeconfig left empty so client-go resolves KUBECONFIG itself

--- a/guides/KUBERNETES_USAGE.md
+++ b/guides/KUBERNETES_USAGE.md
@@ -107,7 +107,7 @@ gonzo --k8s-enabled=true \
 --k8s-selector SELECTOR     # Kubernetes label selector
 --k8s-tail N                # Number of previous log lines per pod (default: 10)
 --k8s-since SECONDS         # Only logs newer than N seconds
---k8s-kubeconfig PATH       # Path to kubeconfig (default: ~/.kube/config)
+--k8s-kubeconfig PATH       # Path to kubeconfig (default: $KUBECONFIG or ~/.kube/config)
 --k8s-context CONTEXT       # Kubernetes context to use
 ```
 
@@ -148,6 +148,10 @@ See [examples/k8s_config.yml](../examples/k8s_config.yml) for a complete example
 ```bash
 # Use specific kubeconfig
 export KUBECONFIG=/path/to/custom/kubeconfig
+
+# Multiple kubeconfig files are merged, as described in the Kubernetes docs
+# (https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable)
+export KUBECONFIG=~/.kube/config:~/.kube/other-config
 
 # Set default Kubernetes context
 export KUBE_CONTEXT=production-cluster

--- a/internal/k8s/config.go
+++ b/internal/k8s/config.go
@@ -2,8 +2,6 @@ package k8s
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -24,22 +22,21 @@ type Config struct {
 func NewDefaultConfig() *Config {
 	tailLines := int64(10) // Default to last 10 lines to avoid overwhelming UI
 	return &Config{
-		Kubeconfig: getDefaultKubeconfig(),
 		Namespaces: []string{""}, // Empty string means all namespaces
 		TailLines:  tailLines,    // Show only recent logs by default
 	}
 }
 
-// getDefaultKubeconfig returns the default kubeconfig path
-func getDefaultKubeconfig() string {
-	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
-		return kubeconfig
+// DetectKubeconfig returns the kubeconfig files to load if they hold at least
+// one context, otherwise nil. KUBECONFIG may list several paths, which
+// client-go splits and merges.
+func DetectKubeconfig() []string {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	config, err := loadingRules.Load()
+	if err != nil || len(config.Contexts) == 0 {
+		return nil
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".kube", "config")
+	return loadingRules.GetLoadingPrecedence()
 }
 
 // BuildClientset creates a kubernetes clientset from the configuration
@@ -47,13 +44,12 @@ func (c *Config) BuildClientset() (*kubernetes.Clientset, error) {
 	// Try in-cluster config first
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		// Fall back to kubeconfig
-		if c.Kubeconfig == "" {
-			c.Kubeconfig = getDefaultKubeconfig()
+		// Fall back to kubeconfig: client-go resolves KUBECONFIG (which may list
+		// several files to merge) and ~/.kube/config on its own.
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		if c.Kubeconfig != "" {
+			loadingRules.ExplicitPath = c.Kubeconfig
 		}
-
-		// Load kubeconfig
-		loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: c.Kubeconfig}
 		configOverrides := &clientcmd.ConfigOverrides{}
 
 		// Override context if specified

--- a/internal/k8s/config_test.go
+++ b/internal/k8s/config_test.go
@@ -1,0 +1,57 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeKubeconfig writes a minimal kubeconfig holding a single context.
+func writeKubeconfig(t *testing.T, path, context string) string {
+	t.Helper()
+	content := "apiVersion: v1\nkind: Config\nclusters:\n- name: " + context +
+		"\n  cluster:\n    server: https://example.invalid\ncontexts:\n- name: " + context +
+		"\n  context:\n    cluster: " + context + "\n    user: " + context +
+		"\nusers:\n- name: " + context + "\n  user: {}\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDetectKubeconfig(t *testing.T) {
+	dir := t.TempDir()
+	first := writeKubeconfig(t, filepath.Join(dir, "config"), "first")
+	second := writeKubeconfig(t, filepath.Join(dir, "staging-config"), "second")
+	missing := filepath.Join(dir, "missing")
+
+	empty := filepath.Join(dir, "empty-config")
+	if err := os.WriteFile(empty, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sep := string(filepath.ListSeparator)
+
+	tests := []struct {
+		name       string
+		kubeconfig string
+		want       []string
+	}{
+		{"single file", first, []string{first}},
+		{"single missing file", missing, nil},
+		{"file without context", empty, nil},
+		{"multiple files", first + sep + second, []string{first, second}},
+		{"multiple files with one missing", missing + sep + second, []string{missing, second}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KUBECONFIG", tt.kubeconfig)
+			got := DetectKubeconfig()
+			if strings.Join(got, sep) != strings.Join(tt.want, sep) {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
KUBECONFIG may list several kubeconfig files to merge, but the whole value was used as a single path: clientcmd got it as ExplicitPath, and auto-detect ran os.Stat on the joined string, so Gonzo silently fell back to system logs.

Let client-go resolve the location instead of reimplementing it. BuildClientset now starts from NewDefaultClientConfigLoadingRules, which splits and merges KUBECONFIG and falls back to ~/.kube/config, and sets ExplicitPath only for --k8s-kubeconfig. As in kubectl, that flag stays a single file; merging is a KUBECONFIG feature. Auto-detect loads the merged config and checks that it holds at least one context.

Closes #147